### PR TITLE
Make "/" default path_url

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -32,16 +32,6 @@
                 "example": "example.com"
             },
             {
-                "name": "path",
-                "type": "path",
-                "ask": {
-                    "en": "Choose a path for Streama (only / is accepted)",
-                    "fr": "Choisissez un chemin pour Streama (seulement / est accepté)"
-                },
-                "example": "/",
-                "default": "/"
-            },
-            {
                 "name": "is_public",
                 "type": "boolean",
                 "ask": {

--- a/scripts/install
+++ b/scripts/install
@@ -25,7 +25,7 @@ ynh_abort_if_errors
 
 # Retrieve arguments
 domain=$YNH_APP_ARG_DOMAIN
-path_url=$YNH_APP_ARG_PATH
+path_url="/"
 is_public=$YNH_APP_ARG_IS_PUBLIC
 
 app=$YNH_APP_INSTANCE_NAME


### PR DESCRIPTION
Since it is not possible to use a path other than "/", this PR removes the path request from the installation and integrates the path "/" as the default path.
I tested, it works.
But I’m slowly discovering app packaging for Yunohost (I’m not a developper at all), so maybe I do bad mistakes... I’ve only based my changes on synapse_ynh which set defaut path at "/_matrix".

I don’t know what you think about it @ericgaspar ?